### PR TITLE
Use CXXFLAGS & LDFLAGS set in the environment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ endif()
 
 include_directories( ${GDAL_INCLUDE_DIR} )
 
+# Hardening buildflags
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{CXXFLAGS}")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} $ENV{LDFLAGS}")
+
 # Creating entries for target: pprepair
 # ############################
 


### PR DESCRIPTION
This change is required to enable all [hardening buildflags](https://wiki.debian.org/Hardening) for the Debian package builds.