### PR TITLE
Fix bug with incomplete .prj files (spatial ref)

### DIFF
--- a/IOWorker.cpp
+++ b/IOWorker.cpp
@@ -54,8 +54,9 @@ bool IOWorker::addToTriangulation(Triangulation &triangulation, TaggingVector &e
     OGRLayer *dataLayer = dataSource->GetLayer(currentLayer);
     dataLayer->ResetReading();
     OGRSpatialReference* tmp = dataLayer->GetSpatialRef();
-    if ( (tmp != NULL) && (spatialReference != NULL) )
-      spatialReference = tmp->CloneGeogCS();
+    if ( (tmp != NULL) && (spatialReference != NULL) ) {
+      spatialReference = tmp->Clone();
+    }
 		
 		unsigned int numberOfPolygons = dataLayer->GetFeatureCount(true);
 		std::cout << "\tReading layer #" << currentLayer+1 << " (" << numberOfPolygons << " polygons)...";


### PR DESCRIPTION
As only the geographical part of the spatial reference system was cloned, the coordinates of the repaired features were not aligning with the input, while using shapefiles as export format. This fix changes the behavior to clone the original spatial reference system definition.