### PR TITLE
declare 'std::filesystem'

### DIFF
--- a/IOWorker.cpp
+++ b/IOWorker.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "IOWorker.h"
+#include <filesystem>
 
 IOWorker::IOWorker() {
   startingSearchFace = Triangulation::Face_handle();


### PR DESCRIPTION
Missing `std::filesystem` got declared in `IOWorker.cpp`.

fixes #56