### PR TITLE
Move `cmake_minimum_required` to the top of `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-project( pprepair )
-
 cmake_minimum_required(VERSION 3.1)
+
+project( pprepair )
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)
   # Only set CMP0053 to OLD with CMake<3.10, otherwise there is a warning.


### PR DESCRIPTION
This fixes the following warning:

```
CMake Warning (dev) at CMakeLists.txt:22 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```